### PR TITLE
align sysstat-stop with procstat-stop from tool-procstat

### DIFF
--- a/sysstat-stop
+++ b/sysstat-stop
@@ -9,7 +9,14 @@ if [ -e sysstat-pids.txt ]; then
     while read pid; do
         kill -s SIGINT $pid
     done <sysstat-pids.txt
+    find . -name "*stdout.txt" -o -name "*stderr.txt" -o -name "*.json" | while read line; do
+	echo "Compressing: $line"
+	xz -3 -T 0 $line
+    done
 else
     echo "Could not find sysstst-pids.txt"
+    echo "PWD: `/bin/pwd`"
+    echo "LS:"
+    /bin/ls -l
     exit 1
 fi


### PR DESCRIPTION
- provide some context if there is an error

- compress the output files to save (potentially considerable) space