### PR TITLE
Add "-r" option to sar-mem to collect free/used metrics

### DIFF
--- a/sysstat-post-process
+++ b/sysstat-post-process
@@ -118,6 +118,9 @@ if (scalar @sar_files == 1) {
                     } elsif ( /(\d+:\d+:\d+)\s+%smem-10\s+%smem-60\s+%smem-300\s+%smem\s+%fmem-10\s+%fmem-60\s+%fmem-300\s+%fmem$/ ) {
                         #16:19:33     %smem-10  %smem-60 %smem-300     %smem  %fmem-10  %fmem-60 %fmem-300     %fmem
                         $scan_mode = "memory-starved";
+                    } elsif ( /(\d+:\d+:\d+)\s+kbmemfree\s+kbavail\s+kbmemused\s+%memused\s+kbbuffers\s+kbcached\s+kbcommit\s+%commit\s+kbactive\s+kbinact\s+kbdirty$/ ) {
+                        #21:28:50    kbmemfree   kbavail kbmemused  %memused kbbuffers  kbcached  kbcommit   %commit  kbactive   kbinact   kbdirty
+                        $scan_mode = "memory-utilization";
                     }
                     elsif ($scan_mode eq "paging") {
                         if ( /(\d+):(\d+):(\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)$/ ) {
@@ -227,6 +230,66 @@ if (scalar @sar_files == 1) {
                                 $sample{'value'} = $memory_stalled{$time_window};
                                 log_sample($source, \%desc, \%no_names, \%sample);
                             }
+                        } elsif ($_ eq '') {
+                            $scan_mode = '';
+                        }
+                    } elsif ($scan_mode eq "memory-utilization") {
+                        if ( /(\d+):(\d+):(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+\.\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+\.\d+)\s+(\d+)\s+(\d+)\s+(\d+)$/ ) {
+                            #21:28:53      1865772  66317648  28872324     29.63        40  63292632  58318396     59.84  41768712  32304200     11020
+                            my $hour = $1;
+                            my $min = $2;
+                            my $sec = $3;
+                            my $kb_mem_free = $4;
+                            my $kb_available = $5;
+                            my $kb_mem_used = $6;
+                            my $percent_mem_used = $7;
+                            my $kb_buffers = $8;
+                            my $kb_cached = $9;
+                            my $kb_commit = $10;
+                            my $percent_commit = $11;
+                            my $kb_active = $12;
+                            my $kb_inactive = $13;
+                            my $kb_dirty = $14;
+                            $hms_ms = get_hms_ms($hour, $min, $sec);
+                            if (defined $prev_hms_ms and $prev_hms_ms > $hms_ms) {
+                                # hour-minute-second is lower than last reading so one day has passed
+                                $ymd_timestamp_ms = advance_ymd($ymd_timestamp_ms);
+                            }
+                            my %sample = ('end' => $ymd_timestamp_ms + $hms_ms);
+
+                            $desc{'type'} = 'Memory-Free-KB';
+                            $sample{'value'} = $kb_mem_free;
+                            log_sample($source, \%desc, \%no_names, \%sample);
+                            $desc{'type'} = 'Memory-Available-KB';
+                            $sample{'value'} = $kb_available;
+                            log_sample($source, \%desc, \%no_names, \%sample);
+                            $desc{'type'} = 'Memory-Used-KB';
+                            $sample{'value'} = $kb_mem_used;
+                            log_sample($source, \%desc, \%no_names, \%sample);
+                            $desc{'type'} = 'Memory-Used-Percent';
+                            $sample{'value'} = $percent_mem_used;
+                            log_sample($source, \%desc, \%no_names, \%sample);
+                            $desc{'type'} = 'Memory-Buffers-KB';
+                            $sample{'value'} = $kb_buffers;
+                            log_sample($source, \%desc, \%no_names, \%sample);
+                            $desc{'type'} = 'Memory-Cached-KB';
+                            $sample{'value'} = $kb_cached;
+                            log_sample($source, \%desc, \%no_names, \%sample);
+                            $desc{'type'} = 'Memory-Commit-KB';
+                            $sample{'value'} = $kb_commit;
+                            log_sample($source, \%desc, \%no_names, \%sample);
+                            $desc{'type'} = 'Memory-Commit-Percent';
+                            $sample{'value'} = $percent_commit;
+                            log_sample($source, \%desc, \%no_names, \%sample);
+                            $desc{'type'} = 'Memory-Active-KB';
+                            $sample{'value'} = $kb_active;
+                            log_sample($source, \%desc, \%no_names, \%sample);
+                            $desc{'type'} = 'Memory-Inactive-KB';
+                            $sample{'value'} = $kb_inactive;
+                            log_sample($source, \%desc, \%no_names, \%sample);
+                            $desc{'type'} = 'Memory-Dirty-KB';
+                            $sample{'value'} = $kb_dirty;
+                            log_sample($source, \%desc, \%no_names, \%sample);
                         } elsif ($_ eq '') {
                             $scan_mode = '';
                         }

--- a/sysstat-start
+++ b/sysstat-start
@@ -79,8 +79,9 @@ for subtool in `echo $subtools | sed -e 's/,/ /g'`; do
             echo "iostat pid is $iostat_pid"
             ;;
         sar)
-            echo "Starting sar"
-            TZ=UTC S_TIME_FORMAT=ISO sar -n ALL -B -q ALL -W -H -m ALL -w $interval >sar-stdout.txt 2>sar-stderr.txt &
+            cmd=(sar -r -n ALL -B -q ALL -W -H -m ALL -w $interval)
+            echo "Starting sar: ${cmd[@]}"
+            TZ=UTC S_TIME_FORMAT=ISO "${cmd[@]}" >sar-stdout.txt 2>sar-stderr.txt &
             sar_pid=$!
             echo "$sar_pid" >>sysstat-pids.txt
             echo "sar pid is $sar_pid"


### PR DESCRIPTION
I (+Claude) added "-r" to sar-mem to collect additonal metrics.

**Previous:**
"types: Page-faults-sec KB-Paged-in-sec KB-Paged-out-sec Pages-freed-sec Pages-swapped-in-sec VM-Efficiency kswapd-scanned-pages-sec reclaimed-pages-sec scanned-pages-sec"

**With "-r":**
"types: Page-faults-sec KB-Paged-out-sec Memory-Active-KB Memory-Available-KB Memory-Buffers-KB Memory-Cached-KB Memory-Commit-KB Memory-Commit-Percent Memory-Dirty-KB Memory-Free-KB Memory-Inactive-KB Memory-Used-KB Memory-Used-Percent Pages-freed-sec KB-Paged-in-sec VM-Efficiency kswapd-scanned-pages-
sec reclaimed-pages-sec"

**The added are:** 
- Memory-Free-KB
- Memory-Available-KB
- Memory-Buffers-KB
- Memory-Cached-KB
- Memory-Active-KB
- Memory-Inactive-KB
- Memory-Used-KB
- Memory-Commit-KB
- Memory-Commit-Percent
- Memory-Dirty-KB

Should we commit?  Or make it an argument option? Or keep it on the side for personal use?
