### PR TITLE
fix: wait before compress and normalize pidstat CPU values

### DIFF
--- a/sysstat-post-process.py
+++ b/sysstat-post-process.py
@@ -506,7 +506,7 @@ def process_pidstat(log_file):
             for field_name, val in fields.items():
                 names = {"cmd": command, "pid": pid, "type": field_name}
                 desc["type"] = "NonBusy-CPU" if field_name == "wait" else "Busy-CPU"
-                sample = {"end": time_ms, "value": val}
+                sample = {"end": time_ms, "value": val / 100}
                 metrics.log_sample("pidstat", desc, names, sample)
 
     fh.close()

--- a/sysstat-stop
+++ b/sysstat-stop
@@ -9,12 +9,13 @@ if [ -e sysstat-pids.txt ]; then
     while read pid; do
         kill -s SIGINT $pid
     done <sysstat-pids.txt
-    find . -name "*stdout.txt" -o -name "*stderr.txt" -o -name "*.json" | while read line; do
-	echo "Compressing: $line"
-	xz -3 -T 0 $line
+    wait
+    find . -name "*stdout.txt" -o -name "*stderr.txt" -o -name "*.json" | while read -r line; do
+        echo "Compressing: $line"
+        xz -3 -T 0 "$line"
     done
 else
-    echo "Could not find sysstst-pids.txt"
+    echo "Could not find sysstat-pids.txt"
     echo "PWD: `/bin/pwd`"
     echo "LS:"
     /bin/ls -l


### PR DESCRIPTION
## Summary

- Add `wait` after killing collector processes before xz compression to prevent corrupting the last sample
- Fix "sysstst" → "sysstat" typo in error message, add `-r` flag to `while read`, quote filename variable
- Normalize pidstat CPU values from 0-100 to 0-1 range to match mpstat's convention for the same Busy-CPU/NonBusy-CPU metric types

## Test plan

- [ ] `crucible run` with sysstat tool completes — verify compressed output is not truncated
- [ ] pidstat metrics in CDM show values in 0-1 range consistent with mpstat

Resolves https://github.com/perftool-incubator/tool-sysstat/issues/60

🤖 Generated with [Claude Code](https://claude.com/claude-code)