### PR TITLE
fix: use throughput class and sum aggregation for CPU metrics

### DIFF
--- a/sysstat-post-process.py
+++ b/sysstat-post-process.py
@@ -328,7 +328,7 @@ def process_mpstat(fork_idx, num_forks, log_file, cpu_topo):
     ymd_timestamp_ms = None
     hms_ms = None
     prev_hms_ms = None
-    desc = {"class": "percentage", "source": "mpstat", "default-aggregation": "avg"}
+    desc = {"class": "throughput", "source": "mpstat", "default-aggregation": "sum"}
     sample = {}
 
     try:
@@ -511,7 +511,7 @@ def process_pidstat(log_file):
             time_ms = ymd_timestamp_ms + hms_ms
 
             command = m.group(12)
-            desc = {"source": "pidstat", "class": "percentage", "default-aggregation": "avg"}
+            desc = {"source": "pidstat", "class": "throughput", "default-aggregation": "sum"}
             fields = {"usr": float(m.group(6)), "system": float(m.group(7)), "guest": float(m.group(8)), "wait": float(m.group(9))}
 
             for field_name, val in fields.items():


### PR DESCRIPTION
## Summary
- Changed mpstat and pidstat `Busy-CPU`/`NonBusy-CPU` metric descriptors from `class: "percentage"` / `default-aggregation: "avg"` to `class: "throughput"` / `default-aggregation: "sum"`
- The CPU type fields (usr, sys, soft, irq, etc.) are mutually exclusive time slices that must be summed when aggregating across the `type` breakout — `avg` produced incorrect results (e.g. 24.8% for a 99.3% busy CPU)
- Class changed to `throughput` because post-aggregation across multiple CPUs the value can exceed 100%

Closes #65
Closes #66

## Test plan
- [ ] Run a benchmark with sysstat tool enabled
- [ ] Query `mpstat::Busy-CPU` with breakout by hostname + CPU num (no type) — verify the value matches the sum of individual types
- [ ] Query `pidstat::Busy-CPU` similarly — verify correct aggregation

🤖 Generated with [Claude Code](https://claude.com/claude-code)